### PR TITLE
SDT-633_Bump-Template-Library

### DIFF
--- a/app/uk/gov/hmrc/taasexamplefrontend/views/error_template.scala.html
+++ b/app/uk/gov/hmrc/taasexamplefrontend/views/error_template.scala.html
@@ -29,7 +29,7 @@
   <p>@message</p>
 }
 
-@FrontendGlobal.localTemplateRenderer.parseTemplate(layouts.article(mainContent), Map(
+@FrontendGlobal.localTemplateRenderer.renderDefaultTemplate(layouts.article(mainContent), Map(
  "pageTitle" -> pageTitle,
  "mainContentHeader" -> contentHeader
 ))

--- a/app/uk/gov/hmrc/taasexamplefrontend/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/taasexamplefrontend/views/main_template.scala.html
@@ -34,7 +34,7 @@
 }
 
 
-@FrontendGlobal.localTemplateRenderer.parseTemplate(layouts.article(mainContent), Map(
+@FrontendGlobal.localTemplateRenderer.renderDefaultTemplate(layouts.article(mainContent), Map(
     "pageTitle" -> title,
     "sidebar" -> sidebar,
     "betaBanner" -> true,

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -17,7 +17,7 @@ object FrontendBuild extends Build with MicroService {
     "uk.gov.hmrc" %% "play-partials" % "5.4.0",
     "uk.gov.hmrc" %% "play-authorised-frontend" % "6.4.0",
     "uk.gov.hmrc" %% "play-config" % "4.3.0",
-    "uk.gov.hmrc" %% "local-template-renderer" % "0.7.0",
+    "uk.gov.hmrc" %% "local-template-renderer" % "0.8.0",
     "uk.gov.hmrc" %% "logback-json-logger" % "3.1.0",
     "uk.gov.hmrc" %% "play-health" % "2.1.0",
     "uk.gov.hmrc" %% "play-ui" % "7.4.0"


### PR DESCRIPTION
Updated to use the 0.8.0 version of the local-template-renderer library 